### PR TITLE
Cdp position tracking

### DIFF
--- a/contracts/CDPosition.sol
+++ b/contracts/CDPosition.sol
@@ -22,6 +22,10 @@ contract CDPosition {
 
     mapping(uint256 => cdp) internal nftCDP;
 
+    uint256 internal _totalNftEntries;
+    uint256[] internal _nftIDArray; // list out all valid and live NFT ID
+    mapping(uint256 => uint256) internal _nftIDToArrayLocation;
+
     /// @dev add new entry to nftid<>CPP map with ousdPrinciple.
     /// Set CDP.firstCycle = true
     /// Update both principle and total with OUSDPrinciple
@@ -175,13 +179,6 @@ contract CDPosition {
         return nftCDP[nftID].firstCycle;
     }
 
-    /// Public for testing
-    uint256 public _totalNftEntries;
-    uint256[] public _nftIDArray; // list out all valid and live NFT ID
-    mapping(uint256 => uint256) public _nftIDToArrayLocation;
-
-    // end public for testing
-
     function _addPositionToTrackingArray(uint256 nftID) internal {
         _nftIDArray.push(nftID); // Push nft to end of array
         _nftIDToArrayLocation[nftID] = _totalNftEntries; // the index location of nftID in array
@@ -191,14 +188,6 @@ contract CDPosition {
     function _deletePositionFromTrackingArray(uint256 nftID) internal {
         uint256 nftToDeleteArrayIndex = _nftIDToArrayLocation[nftID];
         uint256 nftIDToSave = _nftIDArray[_totalNftEntries - 1]; // last valid nft id in array
-
-        console.log(
-            "%s nft is in location in array %s",
-            nftID,
-            _nftIDToArrayLocation[nftID]
-        );
-        console.log("total entries at this stage is  %s", _totalNftEntries);
-        console.log("nftIDToSave", nftIDToSave);
         // swap _nftIDArray[nftToDeleteArrayIndex] with last entry in array 
         _nftIDArray[nftToDeleteArrayIndex] = nftIDToSave;
         _nftIDToArrayLocation[nftID] = 0; // delete last entry in array now that is not being used anymore

--- a/contracts/CDPosition.sol
+++ b/contracts/CDPosition.sol
@@ -31,6 +31,7 @@ contract CDPosition {
         external
         nftIDMustNotExist(nftID)
     {
+        _addPositionToTrackingArray(nftID);
         nftCDP[nftID] = cdp(oOUSDPrinciple, 0, oOUSDPrinciple, 0, true);
     }
 
@@ -42,6 +43,7 @@ contract CDPosition {
         nftIDMustExist(nftID)
         canDeletePosition(nftID)
     {
+        _deletePositionFromTrackingArray(nftID);
         /// Set all values to default. Not way to remove key from mapping in solidity
         delete nftCDP[nftID];
     }
@@ -171,5 +173,36 @@ contract CDPosition {
         returns (bool)
     {
         return nftCDP[nftID].firstCycle;
+    }
+
+    /// Public for testing
+    uint256 public _totalNftEntries;
+    uint256[] public _nftIDArray; // list out all valid and live NFT ID
+    mapping(uint256 => uint256) public _nftIDToArrayLocation;
+
+    // end public for testing
+
+    function _addPositionToTrackingArray(uint256 nftID) internal {
+        _nftIDArray.push(nftID); // Push nft to end of array
+        _nftIDToArrayLocation[nftID] = _totalNftEntries; // the index location of nftID in array
+        _totalNftEntries += 1;
+    }
+
+    function _deletePositionFromTrackingArray(uint256 nftID) internal {
+        uint256 nftToDeleteArrayIndex = _nftIDToArrayLocation[nftID];
+        uint256 nftIDToSave = _nftIDArray[_totalNftEntries - 1]; // last valid nft id in array
+
+        console.log(
+            "%s nft is in location in array %s",
+            nftID,
+            _nftIDToArrayLocation[nftID]
+        );
+        console.log("total entries at this stage is  %s", _totalNftEntries);
+        console.log("nftIDToSave", nftIDToSave);
+        // swap _nftIDArray[nftToDeleteArrayIndex] with last entry in array 
+        _nftIDArray[nftToDeleteArrayIndex] = nftIDToSave;
+        _nftIDToArrayLocation[nftID] = 0; // delete last entry in array now that is not being used anymore
+
+        _totalNftEntries -= 1;
     }
 }

--- a/test/CDPosition.js
+++ b/test/CDPosition.js
@@ -59,28 +59,6 @@ describe("CDPosition test suit", function () {
         })
     });
 
-    describe("Create and delete multiple Position", () => {
-        let NFT_ID_THIRD = 345234
-        it("Should ", async () => {
-            await cdp.createPosition(NFT_ID
-                , BASIC_OUSD_PRINCIPLE)
-            await cdp.createPosition(NFT_ID_SECONDARY
-                , BASIC_OUSD_PRINCIPLE)
-            await cdp.createPosition(NFT_ID_THIRD
-                , BASIC_OUSD_PRINCIPLE)
-            expect(await cdp._totalNftEntries()).to.equal(3)
-            await cdp.deletePosition(NFT_ID_SECONDARY)
-            expect(await cdp._totalNftEntries()).to.equal(2)
-            expect(await cdp._nftIDArray(0)).to.equal(NFT_ID)
-            expect(await cdp._nftIDArray(1)).to.equal(NFT_ID_THIRD)
-        });
-
-        // describe("Delete secondary NFT ID position", async () => {
-        //     await cdp.deletePosition(NFT_ID_SECONDARY)
-        //     /// Add an it
-        // });
-    });
-
     describe("Delete Position", function () {
         it("Should delete position", async function () {
             await cdp.createPosition(NFT_ID

--- a/test/CDPosition.js
+++ b/test/CDPosition.js
@@ -59,6 +59,28 @@ describe("CDPosition test suit", function () {
         })
     });
 
+    describe("Create and delete multiple Position", () => {
+        let NFT_ID_THIRD = 345234
+        it("Should ", async () => {
+            await cdp.createPosition(NFT_ID
+                , BASIC_OUSD_PRINCIPLE)
+            await cdp.createPosition(NFT_ID_SECONDARY
+                , BASIC_OUSD_PRINCIPLE)
+            await cdp.createPosition(NFT_ID_THIRD
+                , BASIC_OUSD_PRINCIPLE)
+            expect(await cdp._totalNftEntries()).to.equal(3)
+            await cdp.deletePosition(NFT_ID_SECONDARY)
+            expect(await cdp._totalNftEntries()).to.equal(2)
+            expect(await cdp._nftIDArray(0)).to.equal(NFT_ID)
+            expect(await cdp._nftIDArray(1)).to.equal(NFT_ID_THIRD)
+        });
+
+        // describe("Delete secondary NFT ID position", async () => {
+        //     await cdp.deletePosition(NFT_ID_SECONDARY)
+        //     /// Add an it
+        // });
+    });
+
     describe("Delete Position", function () {
         it("Should delete position", async function () {
             await cdp.createPosition(NFT_ID


### PR DESCRIPTION
**Whats in this PR** 
- implementing some logic to track which positions are open in an array. 

**Why is this being implemented**
When we plan to pay interest, we'll need to go over all positions but previously we only had a mapping for positions which is not cheaply interpretable. We need the list in a compact array for traversing it

**How**
Whenever we create a position ,we push NFT to array. We also keep track of what array index that NFT ID is at. 

When we delete a position, we swap the deleted NFT ID in the array to the end of the array and delete it (we need to swap to end so we wont have gaps in the tracking arrray)

**Why do we need this change?**
We need to know all NFT IDs that are live in order to pay interest. Using the regular mapping of NFT ID<> CDP is not possible as we cant iterate over all possible keys 