### PR TITLE
chore(ci): cache npm deps

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -23,15 +23,16 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
           token: '${{ secrets.PAT }}'
       
       - name: Setup NodeJS 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3 
         with:
           node-version: 16.x
+          cache: 'npm'
           
       - name: Show NodeJS version    
         run: npm --version

--- a/README.md
+++ b/README.md
@@ -10,4 +10,3 @@ We build in public - so here is how we do stuff in
 Common issues
 
 - "ProviderError: Must be authenticated!": related to git hub private repo not being able to be checked out. One simple fix is to clone secrets repo inside this folder to have root/secrets
-

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ We build in public - so here is how we do stuff in
 Common issues
 
 - "ProviderError: Must be authenticated!": related to git hub private repo not being able to be checked out. One simple fix is to clone secrets repo inside this folder to have root/secrets
+


### PR DESCRIPTION
There was already a cache in the previous actions version but upgrading and running it this way seems to decrease secondary build times by ~45 seconds.
[build with change](https://github.com/thisisarchimedes/Archimedes_Finance/runs/6205621945?check_suite_focus=true)
[build without change](https://github.com/thisisarchimedes/Archimedes_Finance/runs/6205622743?check_suite_focus=true) (one new dependency here but unlikely to be causing such a difference)