### PR TITLE
fix: remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,5 @@
         "prettier": "^2.6.2",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solhint": "^3.3.7"
-    },
-    "dependencies": {
-        "@remix-project/remixd": "^0.6.1",
-        "truffle": "^5.5.10"
     }
 }


### PR DESCRIPTION
There are some security warnings associated with these packages and since remixd and truffle are not required by any source files we can safely remove them. If these packages are still useful for local development we can add documentation to install them globally instead of in the project. For example official docs for these packages recommend running:

`npm install -g @remix-project/remixd` for remixd (see https://github.com/ethereum/remix-project/tree/master/libs/remixd#installation)

`npm install -g truffle` for truffle (see https://github.com/trufflesuite/truffle#install)