### PR TITLE
Add dependabot file for automatic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      commit-message:
+          prefix: "fix"
+          include: "scope"


### PR DESCRIPTION
Similar to [OpenZepplin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/renovate.json) which uses [renovate](https://github.com/renovatebot/renovate) we want to automatically bump versions for our dependencies when they become available. This can help notify us and fix security issues automatically.