### PR TITLE
Add hardhat watcher plugin

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -44,7 +44,7 @@ jobs:
               run: npm run lint
 
             - name: Run project tests
-              run: npm run test
+              run: npm run test:ci
 
             - name: Compile contracts
               run: npx hardhat compile

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,6 +5,8 @@ import "@typechain/hardhat";
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-waffle";
 
+import "hardhat-watcher";
+
 import { task } from "hardhat/config";
 import dotenv from "dotenv";
 
@@ -21,6 +23,16 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
     for (const account of accounts) {
         console.log(account.address);
     }
+});
+
+task("test:watch", "For hardhat watch to run tests on save for both test and sol files", async (taskArgs: { path: string }, hre) => {
+    /* testFiles is always an array of one file: */
+    let { path } = taskArgs;
+    if (path.match(/\.sol$/)) {
+        path = path.replace(/^contracts\/([^.]+).sol$/, "test/$1.ts");
+        console.log(`Running matching test ${path} for changed Solidity file ${taskArgs.path}`);
+    }
+    hre.run("test", { testFiles: [path] });
 });
 
 // You need to export an object to set up your config
@@ -49,5 +61,12 @@ export default {
         alwaysGenerateOverloads: false,
         // optional array of glob patterns with external artifacts to process (for example external libs from node_modules)
         externalArtifacts: ["externalArtifacts/*.json"],
+    },
+    watcher: {
+        test: {
+            tasks: [{ command: "test:watch", params: { path: "{path}" } }],
+            files: ["./test/**/*", "./contracts/**/*"],
+            verbose: true,
+        },
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "ethereum-waffle": "^3.4.4",
                 "ethers": "^5.6.5",
                 "hardhat": "^2.9.5",
+                "hardhat-watcher": "^2.3.0",
                 "mocha": "^10.0.0",
                 "prettier": "^2.6.2",
                 "prettier-plugin-solidity": "^1.0.0-beta.19",
@@ -11655,6 +11656,18 @@
             },
             "peerDependencies": {
                 "chai": "^4.2.0"
+            }
+        },
+        "node_modules/hardhat-watcher": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/hardhat-watcher/-/hardhat-watcher-2.3.0.tgz",
+            "integrity": "sha512-u76a/1pxPyW9DRZ7FZ8HoSQ4AuKOiSDQTR2NyiZlH5f0Ux+qQfahsh9CNusRLhx2s1OWzlkwCVvrdHq5FTGUzw==",
+            "dev": true,
+            "dependencies": {
+                "chokidar": "^3.5.3"
+            },
+            "peerDependencies": {
+                "hardhat": "^2.0.0"
             }
         },
         "node_modules/hardhat/node_modules/debug": {
@@ -28030,6 +28043,15 @@
                     "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
                     "dev": true
                 }
+            }
+        },
+        "hardhat-watcher": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/hardhat-watcher/-/hardhat-watcher-2.3.0.tgz",
+            "integrity": "sha512-u76a/1pxPyW9DRZ7FZ8HoSQ4AuKOiSDQTR2NyiZlH5f0Ux+qQfahsh9CNusRLhx2s1OWzlkwCVvrdHq5FTGUzw==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^3.5.3"
             }
         },
         "has": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
         "lint:ts:fix": "eslint --fix .",
         "lint:sol": "solhint contracts/**/*.sol && prettier --check \"contracts/**/*.sol\"",
         "lint:sol:fix": "solhint contracts/**/*.sol --fix && prettier --write \"contracts/**/*.sol\"",
-        "test": "npm run clean && npm run typechain && hardhat test",
-        "typechain": "npx hardhat typechain"
+        "test:ci": "npm run clean && npm run typechain && npm run test",
+        "test": "hardhat test",
+        "test:watch": "hardhat watch test",
+        "typechain": "npx hardhat typechain",
+        "typechain:watch": "hardhat watch typechain"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "ethereum-waffle": "^3.4.4",
         "ethers": "^5.6.5",
         "hardhat": "^2.9.5",
+        "hardhat-watcher": "^2.3.0",
         "mocha": "^10.0.0",
         "prettier": "^2.6.2",
         "prettier-plugin-solidity": "^1.0.0-beta.19",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "lint:sol:fix": "solhint contracts/**/*.sol --fix && prettier --write \"contracts/**/*.sol\"",
         "test:ci": "npm run clean && npm run typechain && npm run test",
         "test": "hardhat test",
-        "test:watch": "hardhat watch test",
-        "typechain": "npx hardhat typechain",
+        "test:watch": "hardhat typechain && hardhat watch test",
+        "typechain": "hardhat typechain",
         "typechain:watch": "hardhat watch typechain"
     },
     "repository": {


### PR DESCRIPTION
Running `test:watch` will now compile, test, and generate types for changed files only as they are saved. This speeds up development by running tests much faster and without having to manually run the command after each save.