### PR TITLE
add console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 ehthumbs.db
 Thumbs.db
 soljson*
+ts-node
 
 # Hardhat #
 ###########

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
         "lint:sol": "solhint contracts/**/*.sol && prettier --check \"contracts/**/*.sol\"",
         "lint:sol:fix": "solhint contracts/**/*.sol --fix && prettier --write \"contracts/**/*.sol\"",
         "test:ci": "npm run clean && npm run typechain && npm run test",
+        "console": "ts-node console.ts",
         "test": "hardhat test",
         "test:watch": "hardhat typechain && hardhat watch test",
         "typechain": "hardhat typechain",
         "typechain:watch": "hardhat watch typechain"
-
     },
     "repository": {
         "type": "git",

--- a/repl.ts
+++ b/repl.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env ts-node
+import repl from "repl";
+/* direct references to hardhat properties only work with require in this file: */
+const hardhat = require("hardhat"); /* eslint-disable-line @typescript-eslint/no-var-requires */
+
+const replServer = repl.start({
+    prompt: "> ",
+});
+
+replServer.context.hardhat = hardhat;
+replServer.context.ethers = hardhat.ethers;


### PR DESCRIPTION
This will allow us to easily interact with ethers and other objects from our app to test logic faster than `console.log` or tests

![Untitled](https://user-images.githubusercontent.com/4000247/169178363-ca9c283d-51b1-42a1-a4f3-28760c7d6b08.gif)
