### PR TITLE
Always reset from buildContractTestContext

### DIFF
--- a/test/ContractTestContext.test.ts
+++ b/test/ContractTestContext.test.ts
@@ -1,13 +1,11 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { helperResetNetwork, defaultBlockNumber } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
 
 describe("ContractTestContext", function () {
     let contractTestContext: ContractTestContext;
 
     before(async function () {
-        await helperResetNetwork(defaultBlockNumber);
         contractTestContext = await buildContractTestContext();
     });
 

--- a/test/ContractTestContext.ts
+++ b/test/ContractTestContext.ts
@@ -6,6 +6,8 @@ import {
     address3CRV, abi3CRVToken,
     addressCurveOUSDPool,
     helperSwapETHWith3CRV,
+    helperResetNetwork,
+    defaultBlockNumber,
 } from "./MainnetHelper";
 import { createAndFundMetapool } from "./CurveHelper";
 import type {
@@ -55,6 +57,8 @@ export type ContractTestContext = {
 }
 
 export async function buildContractTestContext (): Promise<ContractTestContext> {
+    await helperResetNetwork(defaultBlockNumber);
+
     const context = {} as ContractTestContext;
 
     [context.owner, context.addr1, context.addr2, context.treasurySigner, context.addr3] = await ethers.getSigners();

--- a/test/Coordinator.ts
+++ b/test/Coordinator.ts
@@ -1,5 +1,5 @@
 
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { ethers } from "hardhat";
 import { helperSwapETHWithOUSD } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";

--- a/test/Coordinator.ts
+++ b/test/Coordinator.ts
@@ -1,10 +1,10 @@
 
-import { assert, expect } from "chai";
+import { expect } from "chai";
 import { ethers } from "hardhat";
-import { helperResetNetwork, helperSwapETHWithOUSD, defaultBlockNumber } from "./MainnetHelper";
+import { helperSwapETHWithOUSD } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
 import type { Coordinator } from "../types/contracts";
-import { parseUnits, formatUnits } from "ethers/lib/utils";
+import { formatUnits } from "ethers/lib/utils";
 
 function getFloatFromBigNum (bigNumValue) {
     return parseFloat(formatUnits(bigNumValue));
@@ -19,8 +19,6 @@ describe("Coordinator Test suit", function () {
     const nftIdAddr2Position = 15426;
 
     before(async function () {
-        await helperResetNetwork(defaultBlockNumber);
-
         r = await buildContractTestContext();
 
         endUserSigner = r.owner;
@@ -283,8 +281,6 @@ describe("Coordinator Test suit", function () {
         let originationFeeAmount;
         let depositedLeveragedOUSD;
         before(async function () {
-            // start with a clean setup
-            await helperResetNetwork(defaultBlockNumber);
             r = await buildContractTestContext();
             endUserSigner = r.owner;
             sharesOwnerAddress = r.coordinator.address;

--- a/test/CurveTests.ts
+++ b/test/CurveTests.ts
@@ -1,12 +1,7 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
-import { helperResetNetwork, defaultBlockNumber } from "./MainnetHelper";
-import { createMetapool, fundMetapool, createAndFundMetapool, getMetapool } from "./CurveHelper";
+import { fundMetapool } from "./CurveHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
-
-function parseBN (bigNumValue) {
-    return parseFloat(parseFloat(ethers.utils.formatUnits(bigNumValue)).toFixed(5));
-}
 
 describe("CurveHelper Test Suite", function () {
     let owner;
@@ -16,8 +11,6 @@ describe("CurveHelper Test Suite", function () {
     let pool;
 
     beforeEach(async function () {
-        // Reset network before integration tests
-        await helperResetNetwork(defaultBlockNumber);
         // Setup & deploy contracts
         r = await buildContractTestContext();
         lvUSD = r.lvUSD;

--- a/test/Exchanger.ts
+++ b/test/Exchanger.ts
@@ -1,4 +1,4 @@
-import { helperResetNetwork, helperSwapETHWithOUSD, defaultBlockNumber } from "./MainnetHelper";
+import { helperSwapETHWithOUSD } from "./MainnetHelper";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
@@ -24,9 +24,6 @@ describe("Exchanger Test suit", function () {
     const closeToRange = parseBN(amountToExchange.mul(2).div(100)); // 2% fee+slippage
 
     beforeEach(async function () {
-        // Reset network before tests
-        await helperResetNetwork(defaultBlockNumber);
-
         // Setup & deploy contracts
         r = await buildContractTestContext();
         lvUSD = r.lvUSD;

--- a/test/LeverageEngine.ts
+++ b/test/LeverageEngine.ts
@@ -2,13 +2,12 @@ import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
-import { defaultBlockNumber, helperResetNetwork, helperSwapETHWithOUSD } from "./MainnetHelper";
+import { helperSwapETHWithOUSD } from "./MainnetHelper";
 
 describe("LeverageEngine test suit", async function () {
     let r: ContractTestContext;
 
     before(async () => {
-        await helperResetNetwork(defaultBlockNumber);
         r = await buildContractTestContext();
     });
 
@@ -71,7 +70,6 @@ describe("LeverageEngine test suit", async function () {
 
         let userInitialOUSD;
         before(async function () {
-            await helperResetNetwork(defaultBlockNumber);
             r = await buildContractTestContext();
             maxCycles = await r.parameterStore.getMaxNumberOfCycles();
             const totalOUSD = await helperSwapETHWithOUSD(r.owner, ethers.utils.parseUnits("5"));

--- a/test/ParameterStore.ts
+++ b/test/ParameterStore.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { helperResetNetwork, defaultBlockNumber } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
 
 describe("ParameterStore test suit", async function () {
@@ -8,7 +7,6 @@ describe("ParameterStore test suit", async function () {
     let r: ContractTestContext;
 
     before(async () => {
-        await helperResetNetwork(defaultBlockNumber);
         r = await buildContractTestContext();
         parameterStore = r.parameterStore;
     });

--- a/test/VaultOUSD.ts
+++ b/test/VaultOUSD.ts
@@ -1,11 +1,6 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import {
-    helperResetNetwork,
-    addressOUSD,
-    helperSwapETHWithOUSD,
-    defaultBlockNumber,
-} from "./MainnetHelper";
+import { addressOUSD, helperSwapETHWithOUSD } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
 
 const getDecimal = (naturalNumber) => {
@@ -25,8 +20,6 @@ describe("VaultOUSD test suit", function () {
     const interestIntoVault = 10;
 
     async function setupAndResetState () {
-        await helperResetNetwork(defaultBlockNumber);
-
         r = await buildContractTestContext();
         sharesOwnerAddress = r.owner.address;
 

--- a/test/zIntegrationTests.ts
+++ b/test/zIntegrationTests.ts
@@ -2,8 +2,8 @@ import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { parseUnits, formatUnits } from "ethers/lib/utils";
 import { expect } from "chai";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
-import { helperResetNetwork, helperSwapETHWithOUSD, defaultBlockNumber, helperSwapETHWith3CRV } from "./MainnetHelper";
-import { createAndFundMetapool, fundMetapool } from "./CurveHelper";
+import { helperSwapETHWithOUSD, helperSwapETHWith3CRV } from "./MainnetHelper";
+import { fundMetapool } from "./CurveHelper";
 import { BigNumber } from "ethers";
 
 let r: ContractTestContext;
@@ -70,9 +70,6 @@ async function printMiscInfo (_r, _user) {
 }
 
 async function setupEnvForIntegrationTests () {
-    // Reset network before integration tests
-    await helperResetNetwork(defaultBlockNumber);
-
     // Setup & deploy contracts
     r = await buildContractTestContext();
     owner = r.owner;


### PR DESCRIPTION
We only do this next to buildContractTestContext where it makes sense to always establish a completely new context. We should bundle these together for simplicity