### PR TITLE
unlimited approvals changed to allowances

### DIFF
--- a/contracts/Coordinator.sol
+++ b/contracts/Coordinator.sol
@@ -60,7 +60,7 @@ contract Coordinator is ICoordinator, ReentrancyGuard {
         _ousd = IERC20(_addressOUSD);
         _paramStore = ParameterStore(addressParamStore);
 
-        // approve VaultOUSD address to spend on behalf of coordinator
+        // approve VaultOUSD address to spend OUSD on behalf of coordinator
         _ousd.safeApprove(_addressVaultOUSD, type(uint256).max);
     }
 

--- a/test/ContractTestContext.test.ts
+++ b/test/ContractTestContext.test.ts
@@ -27,15 +27,6 @@ describe("ContractTestContext", function () {
                 expect(await coordinator.addressOfVaultOUSDToken()).to.equal(contractTestContext.vault.address);
             });
         });
-
-        describe("Init methods will be called", async function () {
-            it("Should set unlimited allowance for exchange to spend Coordinator's lvUSD", async function () {
-                // String in equal is 2^256 -1, max uint256
-                expect(await contractTestContext.lvUSD.allowance(
-                    contractTestContext.exchanger.address, contractTestContext.coordinator.address))
-                    .to.equal("115792089237316195423570985008687907853269984665640564039457584007913129639935");
-            });
-        });
     });
 
     describe("Basic contract import functions", async function () {


### PR DESCRIPTION
- Added a few new comments, fixed some typos in old comments
- Changed unlimited approvals for the curve pools to increaseAllowance calls
- Every increaseAllowance call has an associated line setting approval to zero at the end to prevent any strange double spending or unsafe bugs
- Since the Exchanger doesn't use TransferFrom it has no default max allowance from Coordinator; removed the test that checked for this [https://github.com/thisisarchimedes/Archimedes_Finance/compare/exchange-allowance?expand=1#diff-3156b75e895786c35ebbd974e65cf9daf479b659bbf5bdbdc49e195da864aa7eL31]