### PR TITLE
Add test:log task

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,7 +33,7 @@ task("test:watch", "For hardhat watch to run tests on save for both test and sol
         path = path.replace(/^contracts\/([^.]+).sol$/, "test/$1.ts");
         console.log(`Running matching test ${path} for changed Solidity file ${taskArgs.path}`);
     }
-    await hre.run("test", { testFiles: [path] });
+    await hre.run("test:log", { file: path });
 });
 
 task("test:log", "Run tests with all logger logs", async (taskArgs: { file }, hre) => {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,7 +7,8 @@ import "@nomiclabs/hardhat-waffle";
 
 import "hardhat-watcher";
 
-import { task } from "hardhat/config";
+import { setLoggingEnabled } from "./logger";
+import { task, types } from "hardhat/config";
 import dotenv from "dotenv";
 
 // grab the private api key from the private repo
@@ -32,8 +33,16 @@ task("test:watch", "For hardhat watch to run tests on save for both test and sol
         path = path.replace(/^contracts\/([^.]+).sol$/, "test/$1.ts");
         console.log(`Running matching test ${path} for changed Solidity file ${taskArgs.path}`);
     }
-    hre.run("test", { testFiles: [path] });
+    await hre.run("test", { testFiles: [path] });
 });
+
+task("test:log", "Run tests with all logger logs", async (taskArgs: { file }, hre) => {
+    /* testFiles is always an array of one file: */
+    const { file } = taskArgs;
+    setLoggingEnabled(true);
+    const args = file ? { testFiles: [file] } : undefined;
+    await hre.run("test", args);
+}).addOptionalParam("file", "If provided run tests only on specified file", undefined, types.inputFile);
 
 // You need to export an object to set up your config
 // Go to https://hardhat.org/config/ to learn more

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,7 +37,6 @@ task("test:watch", "For hardhat watch to run tests on save for both test and sol
 });
 
 task("test:log", "Run tests with all logger logs", async (taskArgs: { file }, hre) => {
-    /* testFiles is always an array of one file: */
     const { file } = taskArgs;
     setLoggingEnabled(true);
     const args = file ? { testFiles: [file] } : undefined;

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,11 @@
+let loggingEnabled = false;
+
+export function setLoggingEnabled (newValue: boolean) {
+    loggingEnabled = newValue;
+}
+
+export function logger (...args: any[]) {
+    if (loggingEnabled) {
+        console.log(...args);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "test:ci": "npm run clean && npm run typechain && npm run test",
         "console": "ts-node console.ts",
         "test": "hardhat test",
+        "test:log": "hardhat test:log",
         "test:watch": "hardhat typechain && hardhat watch test",
         "typechain": "hardhat typechain",
         "typechain:watch": "hardhat watch typechain"

--- a/test/Coordinator.ts
+++ b/test/Coordinator.ts
@@ -5,6 +5,7 @@ import { helperSwapETHWithOUSD } from "./MainnetHelper";
 import { buildContractTestContext, ContractTestContext } from "./ContractTestContext";
 import type { Coordinator } from "../types/contracts";
 import { formatUnits } from "ethers/lib/utils";
+import { logger } from "../logger";
 
 function getFloatFromBigNum (bigNumValue) {
     return parseFloat(formatUnits(bigNumValue));
@@ -182,7 +183,7 @@ describe("Coordinator Test suit", function () {
                 before(async function () {
                     /// Get initial state
                     borrowedLvUSDInPositionBeforeLeverage = await r.cdp.getLvUSDBorrowed(nftIdFirstPosition);
-                    console.log("borrowedLvUSDInPositionBeforeLeverage", borrowedLvUSDInPositionBeforeLeverage);
+                    logger("borrowedLvUSDInPositionBeforeLeverage", borrowedLvUSDInPositionBeforeLeverage);
                     /// Test artifact only, Once exchanger is functional we can use the exchange and
                     /// transfer OUSD directly to coordinator
                     await r.externalOUSD.connect(endUserSigner).transfer(coordinator.address, leverageAmount);

--- a/test/zIntegrationTests.ts
+++ b/test/zIntegrationTests.ts
@@ -5,6 +5,7 @@ import { buildContractTestContext, ContractTestContext } from "./ContractTestCon
 import { helperSwapETHWithOUSD, helperSwapETHWith3CRV } from "./MainnetHelper";
 import { fundMetapool } from "./CurveHelper";
 import { BigNumber } from "ethers";
+import { logger } from "../logger";
 
 let r: ContractTestContext;
 let owner: SignerWithAddress;
@@ -40,7 +41,7 @@ function getFloatFromBigNum (bigNumValue) {
 }
 
 async function printPoolState (poolInstance) {
-    console.log(
+    logger(
         "Pool has %s coin0/lvUSD and %s coin1/3CRV",
         getFloatFromBigNum(await poolInstance.balances(0)),
         getFloatFromBigNum(await poolInstance.balances(1)),
@@ -48,13 +49,13 @@ async function printPoolState (poolInstance) {
 }
 
 async function printPositionState (_r, _positionId, overviewMessage = "Printing Position State") {
-    await console.log(overviewMessage);
+    logger(overviewMessage);
     const principle = getFloatFromBigNum(await _r.cdp.getOUSDPrinciple(_positionId));
     const ousdEarned = getFloatFromBigNum(await _r.cdp.getOUSDInterestEarned(_positionId));
     const ousdTotal = getFloatFromBigNum(await _r.cdp.getOUSDTotal(_positionId));
     const lvUSDBorrowed = getFloatFromBigNum(await _r.cdp.getLvUSDBorrowed(_positionId));
     const shares = getFloatFromBigNum(await _r.cdp.getShares(_positionId));
-    console.log("Stats for NFT %s: principle %s, ousdEarned %s, ousdTotal %s, lvUSDBorrowed %s, shares %s",
+    logger("Stats for NFT %s: principle %s, ousdEarned %s, ousdTotal %s, lvUSDBorrowed %s, shares %s",
         _positionId, principle, ousdEarned, ousdTotal, lvUSDBorrowed, shares);
 }
 
@@ -66,7 +67,7 @@ async function printMiscInfo (_r, _user) {
         await _r.externalOUSD.balanceOf(_user.address),
     );
     const vaultOUSDBalance = getFloatFromBigNum(await _r.vault.totalAssets());
-    console.log("OUSD : Treasury balance is %s, Vault Balance is %s, User balance is %s", treasuryBalance, vaultOUSDBalance, userOUSDBalance);
+    logger("OUSD : Treasury balance is %s, Vault Balance is %s, User balance is %s", treasuryBalance, vaultOUSDBalance, userOUSDBalance);
 }
 
 async function setupEnvForIntegrationTests () {
@@ -167,7 +168,7 @@ describe("Test suit for getting leverage", function () {
         await setupEnvForIntegrationTests();
         leverageUserIsTaking = getFloatFromBigNum(
             await r.parameterStore.getAllowedLeverageForPosition(userOUSDPrincipleInEighteenDecimal, numberOfCycles));
-        console.log("Will take %s lev while user has allocation of %s", leverageUserIsTaking,
+        logger("Will take %s lev while user has allocation of %s", leverageUserIsTaking,
             getFloatFromBigNum(await r.leverageAllocator.getAddressToLvUSDAvailable(user.address)));
 
         await approveAndGetLeverageAsUser(userOUSDPrincipleInEighteenDecimal, numberOfCycles, r, user);


### PR DESCRIPTION
Optional way of running tests to show console logs in the tests. By default `npm run test` will not show them after this PR.

Usage:
`npm run test:log`
or one file only:
`npm run test:log -- --file test/Coordinator.ts`